### PR TITLE
Fixed bcolors package install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="bcolors",
-    version='1.0.3',
+    version='1.0.4',
     author="Yogesh Sharma",
     author_email="yks0000@gmail.com",
     description="A module for coloring print statement.",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="bcolors",
-    version='1.0.4',
+    version='1.0.5',
     author="Yogesh Sharma",
     author_email="yks0000@gmail.com",
     description="A module for coloring print statement.",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setuptools.setup(
         "Operating System :: OS Independent",
         'Natural Language :: English',
     ],
-    package_dir={"": "bcolors"},
     packages=["bcolors"],
     python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         'Natural Language :: English',
     ],
     package_dir={"": "bcolors"},
-    packages=packages=["bcolors"],
+    packages=["bcolors"],
     python_requires=">=3.6",
 )
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         'Natural Language :: English',
     ],
     package_dir={"": "bcolors"},
-    packages=setuptools.find_packages(where=""),
+    packages=packages=["bcolors"],
     python_requires=">=3.6",
 )
 


### PR DESCRIPTION
installing from pip would result in only the dist-info being installed and not the bcolors package.

can be tested with:
`pip install git+https://github.com/rayregula/bcolors.git`